### PR TITLE
[FIX] Changed the function from write to action_confirm, changed meth…

### DIFF
--- a/branom_sale/__manifest__.py
+++ b/branom_sale/__manifest__.py
@@ -23,7 +23,7 @@
     'version': '0.1',
 
     # any module necessary for this one to work correctly
-    'depends': ['sale_stock', 'account', 'product'],
+    'depends': ['account', 'product', 'sale_account_taxcloud'],
 
     # always loaded
     'data': [

--- a/branom_sale/models/sale_order.py
+++ b/branom_sale/models/sale_order.py
@@ -12,11 +12,11 @@ class SaleOrder(models.Model):
         ], string="Sales Type")
 
     @api.multi
-    def write(self, values):
-        res = super(SaleOrder, self).write(values)
-        # Only when state is sale and commission, always set the delivered qty to ordered qty
+    def action_confirm(self):
+        res = super(SaleOrder, self).action_confirm()
         for order in self.filtered(lambda o: o.state == 'sale' and o.sales_type == 'commission'):
             for line in order.order_line:
+                line.qty_delivered_method = 'manual'
                 line.qty_delivered = line.product_uom_qty
         return res
 


### PR DESCRIPTION
…od to 'manual'

PR for Delivered Qty not being set to Ordered Qty on Commission Sale Orders. 
Issue: Branom installed/changed their workflow so the function was not being called last. 
Fix: Inherit sale_account_taxcloud and instead extend action_confirm instead of write. Inside change the Delivered Qty Method to Manual to prevent the delivered qty from being overwritten. 